### PR TITLE
Remove deprecated leftShift call

### DIFF
--- a/shared-scripts/java.gradle
+++ b/shared-scripts/java.gradle
@@ -60,10 +60,12 @@ jacocoTestReport {
 	}
 }
 
-task checkTestStyle << {
-	sourceSets.test.java.each { file ->
-		if (file.text.contains("org.junit.Assert")) {
-			throw new GradleException("File $file.name uses junit assertions, please use assertj assertions! See https://joel-costigliola.github.io/assertj/ to learn about assertj.")
+task checkTestStyle {
+	doLast {
+		sourceSets.test.java.each { file ->
+			if (file.text.contains("org.junit.Assert")) {
+				throw new GradleException("File $file.name uses junit assertions, please use assertj assertions! See https://joel-costigliola.github.io/assertj/ to learn about assertj.")
+			}
 		}
 	}
 }


### PR DESCRIPTION
The `Task.leftShift(Closure)` method has been deprecated and replaced with `Task.doLast(Action)` and will be removed in Gradle 5.0.

Instead of doing:
```groovy
task someTask << {
    // Do stuff
}
```

You now do:
```groovy

task someTask {
    doLast {
        // Do stuff
    }
}
```

### Completed:
- [x] Test

---

I don't know if the `Task.leftShift(Closure)` method is used anywhere else