### PR TITLE
Add support for Java 9 and newer

### DIFF
--- a/shared-scripts/common.gradle
+++ b/shared-scripts/common.gradle
@@ -1,5 +1,7 @@
-def javaversion = java.lang.Integer.parseInt(System.getProperty("java.runtime.version").split("\\.")[1])
-if (javaversion < 8) {
+def java_version = System.getProperty("java.runtime.version").split("\\.");
+def java_major_version = java.lang.Integer.parseInt(java_version[0]);
+def java_minor_version = java.lang.Integer.parseInt(java_version[1]);
+if (java_major_version == 1 && java_minor_version < 8) {
 	throw new GradleException("Please use JDK 8 or above!")
 }
 


### PR DESCRIPTION
Java 9 and newer uses the [Semantic Versioning](https://semver.org/) version format, so the version is `9.x.x` instead of `1.9.x`.