### PR TITLE
Fix case when `java.runtime.version` contains only the major version

### DIFF
--- a/shared-scripts/common.gradle
+++ b/shared-scripts/common.gradle
@@ -1,6 +1,13 @@
-def java_version = System.getProperty("java.runtime.version").split("\\.");
+def java_version = System.getProperty("java.runtime.version");
+if (java_version.contains("+")) {
+	java_version = java_version.substring(0, java_version.indexOf('+'));
+}
+if (java_version.contains("-")) {
+	java_version = java_version.substring(0, java_version.indexOf('-'));
+}
+java_version = java_version.split("\\.");
 def java_major_version = java.lang.Integer.parseInt(java_version[0]);
-def java_minor_version = java.lang.Integer.parseInt(java_version[1]);
+def java_minor_version = java_version.length >= 2 ? java.lang.Integer.parseInt(java_version[1]) : 0;
 if (java_major_version == 1 && java_minor_version < 8) {
 	throw new GradleException("Please use JDK 8 or above!")
 }

--- a/shared-scripts/common.gradle
+++ b/shared-scripts/common.gradle
@@ -1,18 +1,3 @@
-def java_version = System.getProperty("java.runtime.version");
-if (java_version.contains("+")) {
-	java_version = java_version.substring(0, java_version.indexOf('+'));
-}
-if (java_version.contains("-")) {
-	java_version = java_version.substring(0, java_version.indexOf('-'));
-}
-java_version = java_version.split("\\.");
-def java_major_version = java.lang.Integer.parseInt(java_version[0]);
-def java_minor_version = java_version.length >= 2 ? java.lang.Integer.parseInt(java_version[1]) : 0;
-if (java_major_version == 1 && java_minor_version < 8) {
-	throw new GradleException("Please use JDK 8 or above!")
-}
-
-
 configurations.all {
 	resolutionStrategy.cacheChangingModulesFor 5, 'minutes'
 }


### PR DESCRIPTION
Turns out that Java 9 and 10 actually omits the minor and patch versions from the `java.runtime.version` property when they’re both `0`, and in accordance with the [Semantic Versioning specification](https://semver.org/#spec-item-10), contains some number in the build metadata field.